### PR TITLE
fix: 修复某些dll读取异常影响预热的问题

### DIFF
--- a/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
@@ -20,10 +20,15 @@ public static class NatashaReferencePathsHelper
             .Default
             .CompileLibraries.SelectMany(cl => cl.ResolveReferencePaths().Where(asmPath =>
             {
-
-                var asmName = AssemblyName.GetAssemblyName(asmPath);
-                return !excludeReferencesFunc(asmName, asmName.Name);
-
+                try
+                {
+                    var asmName = AssemblyName.GetAssemblyName(asmPath);
+                    return !excludeReferencesFunc(asmName, asmName?.Name);
+                }
+                catch
+                {
+                    return false;
+                }
             }));
         }
         catch


### PR DESCRIPTION
一些dll无法正常读取，会影响到整个预热，需要跳过。