### PR TITLE
fix: 修复某些dll读取异常, 从而影响预热的问题

### DIFF
--- a/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
@@ -20,10 +20,15 @@ public static class NatashaReferencePathsHelper
             .Default
             .CompileLibraries.SelectMany(cl => cl.ResolveReferencePaths().Where(asmPath =>
             {
-
-                var asmName = AssemblyName.GetAssemblyName(asmPath);
-                return !excludeReferencesFunc(asmName, asmName.Name);
-
+                try
+                {
+                    var asmName = AssemblyName.GetAssemblyName(asmPath);
+                    return !excludeReferencesFunc(asmName, asmName?.Name);
+                }
+                catch
+                {
+                    return false;
+                }
             }));
         }
         catch

--- a/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
@@ -14,10 +14,9 @@ public static class NatashaReferencePathsHelper
 
 
         IEnumerable<string>? paths = null;
-        try
-        {
-            paths = DependencyContext
-            .Default
+        
+        paths = DependencyContext
+            .Default?
             .CompileLibraries.SelectMany(cl => cl.ResolveReferencePaths().Where(asmPath =>
             {
                 try
@@ -30,11 +29,6 @@ public static class NatashaReferencePathsHelper
                     return false;
                 }
             }));
-        }
-        catch
-        {
-
-        }
 
         if (paths == null || !paths.Any())
         {


### PR DESCRIPTION
某些dll在使用`AssemblyName.GetAssemblyName(asmPath);`会读取失败，这时候预热就会中断，导致预热不完整。