### PR TITLE
解决: 预热时无法读取dll，PE信息中找不到元数据

### DIFF
--- a/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp/Public/NatashaReferencePathsHelper.cs
@@ -25,6 +25,7 @@ public static class NatashaReferencePathsHelper
             {
                 try
                 {
+                    //#ISSUE:178
                     using var peStream = File.OpenRead(asmPath);
                     PEReader pEReader = new PEReader(peStream);
                     PEReader pEReader2 = pEReader;


### PR DESCRIPTION
增加PE元数据检测
#178 