### PR TITLE
增加编译选项，修复调试BUG

### DIFF
--- a/samples/ReferenceSample/Program.cs
+++ b/samples/ReferenceSample/Program.cs
@@ -4,20 +4,26 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Internal;
 using System.Runtime.CompilerServices;
+using static System.Diagnostics.DebuggableAttribute;
+using System.Diagnostics;
+using System.Diagnostics.SymbolStore;
 
 namespace ReferenceSample
 {
+
     internal class Program
     {
+        
         static void Main(string[] args)
         {
             //Run();
-            NatashaManagement.Preheating(true, true);
-            GC.Collect();
-            Thread.Sleep(15000);
+            //NatashaManagement.Preheating(true, true);
+            //GC.Collect();
+            //Thread.Sleep(15000);
+            var method = typeof(Program).GetMethod("TestMini");
             for (int i = 0; i < 5; i++)
             {
-                TestMini();
+                method.Invoke(null,null);
                 Thread.Sleep(3000);
             }
             Console.ReadKey();
@@ -26,6 +32,7 @@ namespace ReferenceSample
 
         public static void TestMini()
         {
+            
             AssemblyCSharpBuilder builder = new AssemblyCSharpBuilder();
             builder
                 .UseRandomDomain()
@@ -34,24 +41,30 @@ namespace ReferenceSample
                         Natasha.CSharp.Compiler.CompilerBinderFlags.SuppressConstraintChecks | 
                         Natasha.CSharp.Compiler.CompilerBinderFlags.SuppressObsoleteChecks | 
                         Natasha.CSharp.Compiler.CompilerBinderFlags.SuppressTypeArgumentBinding | 
-                        Natasha.CSharp.Compiler.CompilerBinderFlags.SuppressUnsafeDiagnostics))
+                        Natasha.CSharp.Compiler.CompilerBinderFlags.SuppressUnsafeDiagnostics)
+                        )
                 .DisableSemanticCheck()
+                .WithDebugCompile(item=>item.WriteToFile())
+                .OutputAsFullAssembly()
+                .WithoutPrivateMembers()
+                .AddReference(typeof(DebuggableAttribute))
                 .AddReference(typeof(object).Assembly)
                 .AddReference(typeof(Math).Assembly)
                 .AddReference(typeof(MathF).Assembly)
                 .ConfigReferenceCombineBehavior(CombineReferenceBehavior.UseCurrent);
 
-            builder.Add(@"public static class A{  
+            builder.Add(@"
+public static class A{  
     public static int N1 = 10;
     public static float N2 = 1.2F; 
     public static double N3 = 3.44;
-
+    private static short N4 = 0;
     public static object Invoke(){
 
         return N1 + MathF.Log10((float)Math.Sqrt(MathF.Sqrt(N2) + Math.Tan(N3)));
     }
 }", UsingLoadBehavior.WithCurrent);
-
+            
             var asm = builder.GetAssembly();
             var type = asm.GetType("A");
             var method = type.GetMethod("Invoke");

--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/MultiDomain/CompileUnit/AssemblyCSharpBuilder.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/MultiDomain/CompileUnit/AssemblyCSharpBuilder.cs
@@ -33,7 +33,6 @@ public sealed partial class AssemblyCSharpBuilder
         SyntaxTrees = new();
         AssemblyName = assemblyName;
         DllFilePath = string.Empty;
-        PdbFilePath = string.Empty;
         XmlFilePath = string.Empty;
     }
 

--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/CompileUnit/AssemblyCSharpBuilder.Ouput.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/CompileUnit/AssemblyCSharpBuilder.Ouput.cs
@@ -10,7 +10,7 @@ public sealed partial class AssemblyCSharpBuilder
     #region 输出设置相关
     public string AssemblyName;
     public string DllFilePath;
-    public string PdbFilePath;
+    public string? PdbFilePath;
     public string XmlFilePath;
     public string OutputFolder;
     /// <summary>

--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/CompileUnit/AssemblyCSharpBuilder.Share.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/CompileUnit/AssemblyCSharpBuilder.Share.cs
@@ -1,7 +1,53 @@
-﻿using System;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using System;
 
 public sealed partial class AssemblyCSharpBuilder
 {
+    private DebugOutput _debugInfo = new DebugOutput();
+
+    private bool _isReferenceAssembly;
+
+    private bool _includePrivateMembers;
+
+    /// <summary>
+    /// pdb文件包含私有字段信息
+    /// </summary>
+    /// <returns></returns>
+    public AssemblyCSharpBuilder WithPrivateMembers()
+    {
+        _includePrivateMembers = true;
+        return this;
+    }
+    /// <summary>
+    /// pdb文件不包含私有字段信息
+    /// </summary>
+    /// <returns></returns>
+    public AssemblyCSharpBuilder WithoutPrivateMembers()
+    {
+        _includePrivateMembers = false;
+        return this;
+    }
+
+    /// <summary>
+    /// 是否以引用程序集方式输出
+    /// </summary>
+    /// <returns></returns>
+    public AssemblyCSharpBuilder OutputAsRefAssembly()
+    {
+        _isReferenceAssembly = true;
+        return this;
+    }
+    /// <summary>
+    /// 是否以完全程序集方式输出
+    /// </summary>
+    /// <returns></returns>
+    public AssemblyCSharpBuilder OutputAsFullAssembly()
+    {
+        _isReferenceAssembly = false;
+        return this;
+    }
+
     /// <summary>
     /// 清空编译信息, 下次编译重组 Compilation 和语法树.
     /// </summary>
@@ -24,17 +70,28 @@ public sealed partial class AssemblyCSharpBuilder
         return this;
     }
 
-    private bool _needGeneratPdb;
-    public AssemblyCSharpBuilder WithoutPdbOutput()
+
+    private OptimizationLevel _codeOptimizationLevel = OptimizationLevel.Release;
+    /// <summary>
+    /// 编译时使用 debug 模式
+    /// </summary>
+    /// <returns></returns>
+    public AssemblyCSharpBuilder WithDebugCompile(Action<DebugOutput>? action = null)
     {
-        _needGeneratPdb = false;
+        action?.Invoke(_debugInfo);
+        _codeOptimizationLevel = OptimizationLevel.Debug;
         return this;
     }
-    public AssemblyCSharpBuilder WithPdbOutput()
+    /// <summary>
+    /// 编译时使用 release 模式优化（默认）
+    /// </summary>
+    /// <returns></returns>
+    public AssemblyCSharpBuilder WithReleaseCompile()
     {
-        _needGeneratPdb = true;
+        _codeOptimizationLevel = OptimizationLevel.Release;
         return this;
     }
+
 
     /// <summary>
     /// 自动使用 GUID 作为程序集名称.

--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/Component/Compiler/Model/DebugOutput.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/Component/Compiler/Model/DebugOutput.cs
@@ -1,0 +1,29 @@
+﻿
+using Microsoft.CodeAnalysis.Emit;
+
+public class DebugOutput
+{
+    
+    internal DebugInformationFormat _informationFormat = DebugInformationFormat.PortablePdb;
+
+    /// <summary>
+    /// 采用文件加载方式搜集源代码信息
+    /// </summary>
+    /// <returns></returns>
+    public DebugOutput WriteToFile()
+    {
+        _informationFormat = DebugInformationFormat.PortablePdb;
+        return this;
+    }
+    /// <summary>
+    /// 将Pdb输出到程序集中，并直接从程序集加载Pdb调试信息
+    /// </summary>
+    /// <returns></returns>
+    public DebugOutput WriteToAssembly()
+    {
+        _informationFormat = DebugInformationFormat.Embedded;
+        return this;
+    }
+    
+}
+

--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/Component/Compiler/NatashaCSharpCompilerOptions.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/Public/Component/Compiler/NatashaCSharpCompilerOptions.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 using Natasha.CSharp.Component.Compiler;
 using Natasha.CSharp.Component.Compiler.Utils;
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 
 namespace Natasha.CSharp.Compiler
@@ -22,7 +24,6 @@ namespace Natasha.CSharp.Compiler
         .SetNullableCompile(NullableContextOptions.Enable)
             .WithoutLowerVersionsAssembly()
             .SetOutputKind(OutputKind.DynamicallyLinkedLibrary)
-            .WithReleaseCompile()
             .WithUnsafeCompile()
             .WithPublicMetadata()
             .SetPlatform(Platform.AnyCpu);
@@ -74,27 +75,6 @@ namespace Natasha.CSharp.Compiler
         public NatashaCSharpCompilerOptions SetNullableCompile(NullableContextOptions flag)
         {
             _nullableCompileOption = flag;
-            return this;
-        }
-
-
-        private OptimizationLevel _codeOptimizationLevel;
-        /// <summary>
-        /// 编译时使用 debug 模式
-        /// </summary>
-        /// <returns></returns>
-        public NatashaCSharpCompilerOptions WithDebugCompile()
-        {
-            _codeOptimizationLevel = OptimizationLevel.Debug;
-            return this;
-        }
-        /// <summary>
-        /// 编译时使用 release 模式优化（默认）
-        /// </summary>
-        /// <returns></returns>
-        public NatashaCSharpCompilerOptions WithReleaseCompile()
-        {
-            _codeOptimizationLevel = OptimizationLevel.Release;
             return this;
         }
 
@@ -221,11 +201,10 @@ namespace Natasha.CSharp.Compiler
         /// 获取构建编译信息的选项
         /// </summary>
         /// <returns></returns>
-        internal CSharpCompilationOptions GetCompilationOptions()
+        internal CSharpCompilationOptions GetCompilationOptions(OptimizationLevel optimizationLevel)
         {
-
             var compilationOptions = new CSharpCompilationOptions(
-                                    nullableContextOptions: _nullableCompileOption,
+                                   nullableContextOptions: _nullableCompileOption,
                                    //strongNameProvider: a,
                                    deterministic: false,
                                    concurrentBuild: true,
@@ -233,7 +212,7 @@ namespace Natasha.CSharp.Compiler
                                    reportSuppressedDiagnostics: _suppressReportShut,
                                    metadataImportOptions: _metadataImportOptions,
                                    outputKind: _assemblyKind,
-                                   optimizationLevel: _codeOptimizationLevel,
+                                   optimizationLevel: optimizationLevel,
                                    allowUnsafe: _allowUnsafe,
                                    platform: _processorPlatform,
                                    checkOverflow: false,

--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/SingleDomain/CompileUnit/AssemblyCSharpBuilder.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/SingleDomain/CompileUnit/AssemblyCSharpBuilder.cs
@@ -31,7 +31,6 @@ public sealed partial class AssemblyCSharpBuilder
         SyntaxTrees = new();
         AssemblyName = assemblyName;
         DllFilePath = string.Empty;
-        PdbFilePath = string.Empty;
         XmlFilePath = string.Empty;
         this.UseNatashaFileOut();
     }

--- a/test/ut/NatashaFunctionUT/DomainPrepare.cs
+++ b/test/ut/NatashaFunctionUT/DomainPrepare.cs
@@ -19,8 +19,8 @@ public class DomainPrepare
              _runtimeVersion = "net5.0";
 #elif NET6_0
         _runtimeVersion = "net6.0";
-#elif NET7_0_OR_GREATER
-        _runtimeVersion = "net7.0";
+#elif NET8_0
+        _runtimeVersion = "net8.0";
 #endif
         DefaultAssembliesCount = AssemblyLoadContext.Default.Assemblies.Count();
         Unsafe.SizeOf<int>();


### PR DESCRIPTION
1. 增加程序集输出选项 WithPrivateMembers/WithoutPrivateMembers/OutputAsRefAssembly/OutputAsFullAssembly
2. 增强调试选项，并支持断点调试 WithDebugCompile