### PR TITLE
fix assembly helper typo

### DIFF
--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/NatashaAssemblyHelper.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/NatashaAssemblyHelper.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-internal static class NatashaAsssemblyHelper
+internal static class NatashaAssemblyHelper
 {
     internal static Assembly[] GetRuntimeAssemblies()
     {

--- a/src/Natasha.CSharp/Natasha.CSharp.Compiler/NatashaInitializer.cs
+++ b/src/Natasha.CSharp/Natasha.CSharp.Compiler/NatashaInitializer.cs
@@ -81,12 +81,12 @@ internal static class NatashaInitializer
                     NatashaLoadContext.DefaultContext.UsingRecorder.Using(namespaceText);
                     if (useRuntimeReference)
                     {
-                        var assemblies = NatashaAsssemblyHelper.GetRuntimeAssemblies();
+                        var assemblies = NatashaAssemblyHelper.GetRuntimeAssemblies();
                         parallelLoopResults.Enqueue(InitReferenceFromRuntime(assemblies));
                     }
                     else
                     {
-                        var paths = NatashaAsssemblyHelper.GetReferenceAssmeblyFiles(excludeReferencesFunc);
+                        var paths = NatashaAssemblyHelper.GetReferenceAssmeblyFiles(excludeReferencesFunc);
                         if (paths != null && paths.Any())
                         {
                             parallelLoopResults.Enqueue(InitReferenceFromPath(paths));
@@ -103,14 +103,14 @@ internal static class NatashaInitializer
                     {
                         if (useRuntimeUsing)
                         {
-                            var assemblies = NatashaAsssemblyHelper.GetRuntimeAssemblies();
+                            var assemblies = NatashaAssemblyHelper.GetRuntimeAssemblies();
                             parallelLoopResults.Enqueue(InitReferenceAndUsingFromRuntime(assemblies));
                         }
                         else
                         {
-                            var assemblies = NatashaAsssemblyHelper.GetRuntimeAssemblies();
+                            var assemblies = NatashaAssemblyHelper.GetRuntimeAssemblies();
                             parallelLoopResults.Enqueue(InitReferenceFromRuntime(assemblies));
-                            var paths = NatashaAsssemblyHelper.GetReferenceAssmeblyFiles(excludeReferencesFunc);
+                            var paths = NatashaAssemblyHelper.GetReferenceAssmeblyFiles(excludeReferencesFunc);
                             if (paths != null && paths.Any())
                             {
                                 parallelLoopResults.Enqueue(InitUsingFromPath(paths));
@@ -123,13 +123,13 @@ internal static class NatashaInitializer
                     }
                     else
                     {
-                        var paths = NatashaAsssemblyHelper.GetReferenceAssmeblyFiles(excludeReferencesFunc);
+                        var paths = NatashaAssemblyHelper.GetReferenceAssmeblyFiles(excludeReferencesFunc);
                         if (paths != null && paths.Any())
                         {
                             if (useRuntimeUsing)
                             {
                                 parallelLoopResults.Enqueue(InitReferenceFromPath(paths));
-                                var assemblies = NatashaAsssemblyHelper.GetRuntimeAssemblies();
+                                var assemblies = NatashaAssemblyHelper.GetRuntimeAssemblies();
                                 parallelLoopResults.Enqueue(InitUsingFromRuntime(assemblies));
                             }
                             else


### PR DESCRIPTION
修改 `Assembly` 拼写错误，多了一个 `s`，`internal` 的类型，应该不会造成破坏性变更